### PR TITLE
Fix unusably small settings popup on Chrome 121

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,6 +1,7 @@
 html {
   background: rgb(29, 31, 33);
   background: linear-gradient(128deg, rgba(29, 31, 33, 1) 0%, rgba(112, 120, 128, 1) 100%);
+  width: fit-content;
 }
 
 body {


### PR DESCRIPTION
Upon first installation of the extension the settings popup was only rendered at minimum width (some 30ish pixels) which made the settings unusable. Adjusted the CSS so that the popup would dynamically choose an appropriate size.